### PR TITLE
Добавление возможности проигрывания звуков в рендомном порядке

### DIFF
--- a/js/ion.sound.js
+++ b/js/ion.sound.js
@@ -61,7 +61,7 @@
             playing_int,
             countRandom;
 
-        if(info == undefined){
+        if (info == undefined) {
             countRandom = Math.floor(Math.random() * soundsNum);
             info = settings.sounds[countRandom];
         }


### PR DESCRIPTION
Данные изменения дают возможность проигрывать любые подключенные звуки в рендомном порядке.
Достаточно в коде прописать $.ionSound.play() без явного указания аргумента. Звук будет проигрываться рендомно любой из подключенных через опцию sounds.
Minifed версию не обновлял!
