### PR TITLE
Fix bug causing sounds to play only once on Chrome

### DIFF
--- a/js/ion.sound.js
+++ b/js/ion.sound.js
@@ -173,6 +173,7 @@ var ion = ion || {};
                     } catch (e) {}
                 }
 
+                this.sound.load();
                 this.sound.play();
             }
         };


### PR DESCRIPTION
Hi,

Thanks for the convenient ion.sound library! I tried using it in a webapp today and ran into one snag under Chrome 38.0.2125.111 m on Windows 8: my sounds would only play once, then never again until the page was reloaded. Someone on StackOverflow [reported similar a problem](http://stackoverflow.com/questions/9335577/html5-audio-sound-only-plays-once) with HTML 5 sound. They fixed the problem by adding an extra .load() on the audio object before each .play(). Making a similar patch to ion.sound fixed it for me.

Regards,
-Jeremy
