### PR TITLE
Fix jQuery as optional dependency

### DIFF
--- a/js/ion.sound.js
+++ b/js/ion.sound.js
@@ -29,7 +29,7 @@
                 console.log(text);
             }
 
-            var d = $("#debug");
+            var d = $ && $("#debug");
             if (d.length) {
                 var a = d.html();
                 d.html(a + text + '<br/>');
@@ -987,4 +987,4 @@
         }
     };
 
-} (window, navigator, jQuery || $));
+} (window, navigator, window.jQuery || window.$));


### PR DESCRIPTION
Check if jQuery is defined before using it and use `window.jQuery` instead of `jQuery` directly to prevent `ReferenceError`.

Note: this pull request doesn't change minified files.