### PR TITLE
Fix name of Bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "ion-sound",
+    "name": "ionsound",
     "version": "3.0.1",
     "homepage": "https://github.com/IonDen/ion.sound",
     "authors": [


### PR DESCRIPTION
As commented in #34 Bower's package name is `ionsound`. At the same time it's `ion-sound` in `bower.json` which is a bit misleading. I believe `bower.json` should be fixed.