### PR TITLE
Fixes: ion.sound.stop not working when not all sounds are loaded

### DIFF
--- a/js/ion.sound.js
+++ b/js/ion.sound.js
@@ -401,7 +401,9 @@
                 }
 
             } else {
-                this.streams[0].stop();
+                if(this.streams.hasOwnProperty(0)) {
+                    this.streams[0].stop();
+                }
             }
         },
 


### PR DESCRIPTION
Sounds which are not loaded yet do not have an streams[0] object and therefore ion.sound.stop() will throw an error, this will fix it