### PR TITLE
Race condition on looped sounds

### DIFF
--- a/js/ion.sound.js
+++ b/js/ion.sound.js
@@ -581,7 +581,7 @@
         },
 
         ended: function () {
-            var wasPlaying = this.playing;
+            var was_playing = this.playing;
             this.playing = false;
             this.time_ended = new Date().valueOf();
             this.time_played = (this.time_ended - this.time_started) / 1000;
@@ -591,7 +591,7 @@
                 this._ended();
                 this.clear();
 
-                if (this.loop && wasPlaying) {
+                if (this.loop && was_playing) {
                     this.loop--;
                     this.play();
                 }

--- a/js/ion.sound.js
+++ b/js/ion.sound.js
@@ -581,6 +581,7 @@
         },
 
         ended: function () {
+            var wasPlaying = this.playing;
             this.playing = false;
             this.time_ended = new Date().valueOf();
             this.time_played = (this.time_ended - this.time_started) / 1000;
@@ -590,7 +591,7 @@
                 this._ended();
                 this.clear();
 
-                if (this.loop) {
+                if (this.loop && wasPlaying) {
                     this.loop--;
                     this.play();
                 }


### PR DESCRIPTION
Basically, this one is really, really, really hard to replicate.
I'd to reload tons of times to try to replicate it and it happens randomly.
So, the thing is that, when a sound had been manually .stop()'ped, browsers as Firefox, can eventually trigger the .ended callback few moments after the .stop() call, which would trigger the sound to loop again.
This is why, I'd added this small additional check that should solve potential race conditions as this one :)