### PR TITLE
Loop keeps playing after stopped, if execution was suspended in debugger for a while

### DIFF
--- a/js/ion.sound.js
+++ b/js/ion.sound.js
@@ -584,12 +584,14 @@
         },
 
         ended: function () {
+            var wasPlaying = this.playing;
+            console.log('wasPlaying:', wasPlaying);
             this.playing = false;
             this.time_ended = new Date().valueOf();
             this.time_played = (this.time_ended - this.time_started) / 1000;
             this.time_offset += this.time_played;
 
-            if (this.time_offset >= this.end || this.end - this.time_offset < 0.015) {
+            if (wasPlaying && (this.time_offset >= this.end || this.end - this.time_offset < 0.015)) {
                 this._ended();
                 this.clear();
 


### PR DESCRIPTION
To reproduce the problem:
1. Start a short sound with  loop: true
2. Put a breakpoint on sound.stop call (or anywhere else, really)
3. Trigger the breakpoint
4. Wait for a bit, then resume execution.

Expected: loop stops
Actual: loop keeps merrily looping after the sound.stop() call. An hour-long dive through the app and the library to figure out what can possible be restarting the loop ensues. Actually, nothing does, it's only the interplay between this if and having JavaScript engine paused for a while when the loop was playing. 

I'm not sure I completely understand the subtleties of (this.time_offset >= this.end || this.end - this.time_offset < 0.015) condition, so maybe this PR breaks some other case I'm not thinking of. But it surely solves the described problem. :)

Please have a close look.